### PR TITLE
Fix quality highlighter issue

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,9 +41,9 @@ This will ensure the entire line will have the same background color, but - depe
 ![Options](images/ColoredPassword%20-%20Entry%20List.png)
 
 # Translations
-ColoredPassword is provided with english language built-in and allow usage of translation files.
+ColoredPassword is provided with English language built-in and allow usage of translation files.
 These translation files need to be placed in a folder called *Translations* inside in your plugin folder.
-If a text is missing in the translation file, it is backfilled with the english text.
+If a text is missing in the translation file, it is backfilled with English text.
 You're welcome to add additional translation files by creating a pull request.
 
 Naming convention for translation files: `<plugin name>.<language identifier>.language.xml`\

--- a/src/ColoredPassword.cs
+++ b/src/ColoredPassword.cs
@@ -184,6 +184,15 @@ namespace ColoredPassword
 				//This way, explicitly set background colors do have higher priority
 				if (cItemBackground == e.Item.ListView.BackColor) cItemBackground = m_cBackgroundColor;
 			}
+			if ((ColorConfig.DrawMode == ColorConfig.ListViewDrawMode.DrawPasswordOnly) && (e.Header.Text != KeePass.Resources.KPRes.Password))
+			{
+				e.Item.BackColor = e.SubItem.BackColor = cItemBackground;
+				e.DrawDefault = true;
+				string m = "m_lvEntries: Standard display for column '" + e.Header.Text + "'";
+				if (!PluginDebug.HasMessage(PluginDebug.LogLevelFlags.Info, m))
+					PluginDebug.AddInfo(m, 0);
+				return;
+			}
 			Font fFont = e.Item.UseItemStyleForSubItems ? e.Item.Font : e.SubItem.Font;
 			if (!e.Item.Selected) e.Graphics.FillRectangle(new SolidBrush(cItemBackground), e.Bounds);
 			int iPadding = 3;
@@ -525,6 +534,25 @@ namespace ColoredPassword
 			}
 		}
 		public static bool ListViewKeepBackgroundColor = true;
+		public static ListViewDrawMode DrawMode
+		{
+			get
+			{
+				if (KeePassLib.Native.NativeLib.IsUnix()) return ListViewDrawMode.DrawAllColumns;
+				string m = KeePass.Program.Config.CustomConfig.GetString("ColoredPassword.DrawMode", ListViewDrawMode.DrawPasswordOnly.ToString());
+				ListViewDrawMode r = ListViewDrawMode.DrawPasswordOnly;
+				try
+				{
+					r = (ListViewDrawMode)Enum.Parse(typeof(ListViewDrawMode), m, true);
+					return r;
+				}
+				catch
+				{
+					KeePass.Program.Config.CustomConfig.SetString("ColoredPassword.DrawMode", ListViewDrawMode.DrawPasswordOnly.ToString());
+					return ListViewDrawMode.DrawPasswordOnly;
+				}
+			}
+		}
 
 		public static void Read(IPluginHost host)
 		{
@@ -622,6 +650,12 @@ namespace ColoredPassword
 			m_BackColorDigitTest = m_BackColorDigit;
 			m_ForeColorSpecialTest = m_ForeColorSpecial;
 			m_BackColorSpecialTest = m_BackColorSpecial;
+		}
+
+		internal enum ListViewDrawMode
+		{
+			DrawAllColumns,
+			DrawPasswordOnly,
 		}
 	}
 }

--- a/src/ColoredPassword.cs
+++ b/src/ColoredPassword.cs
@@ -218,8 +218,10 @@ namespace ColoredPassword
 			{
 				StringFormat sf = StringFormat.GenericTypographic;
 				//Measuring only the to be drawn character produces wrong results
-				float fWidth = e.Graphics.MeasureString("A!r" + s.Substring(i, 1), fFont, int.MaxValue, sf).Width;
-				fWidth -= e.Graphics.MeasureString("A!r", fFont, int.MaxValue, sf).Width;
+				//Place to be measured character inbetween something else
+				//Trailing spacs are skipped and nothing would be shown
+				float fWidth = e.Graphics.MeasureString("A!r" + s.Substring(i, 1) + "A!r", fFont, int.MaxValue, sf).Width;
+				fWidth -= e.Graphics.MeasureString("A!rA!r", fFont, int.MaxValue, sf).Width;
 				if ((e.Bounds.X + e.Bounds.Width) <= (x + fWidth)) break;
 				Color col = ColorConfig.ForeColorDefault;
 				Color colb = ColorConfig.ListViewKeepBackgroundColor ? cItemBackground : ColorConfig.BackColorDefault;
@@ -253,7 +255,8 @@ namespace ColoredPassword
 				PluginDebug.AddInfo(msg, 0, lMsg.ToArray());
 				RectangleF r = new RectangleF(x, e.Bounds.Y + iPaddingY, fWidth, e.Bounds.Height - (2 * iPaddingY));
 				e.Graphics.FillRectangle(new SolidBrush(colb), r);
-				PointF p = new PointF(r.X, r.Y); //Win 7 calculates width of certain characters wrong and they wonÄt be drawn because they're larger than the rectangle
+				//Win 7 calculates width of certain characters wrong and they won't be drawn because they're larger than the rectangle
+				PointF p = new PointF(r.X, r.Y); 
 				e.Graphics.DrawString(s.Substring(i, 1), fFont, new SolidBrush(col), p, sf);
 				x += fWidth;
 				i++;

--- a/src/PluginTools.cs
+++ b/src/PluginTools.cs
@@ -120,7 +120,15 @@ namespace PluginTools
 				while (PluginIterator.MoveNext())
 				{
 					object result = GetField("m_pluginInterface", PluginIterator.Current);
-					dPlugins[result.GetType().FullName] = result.GetType().Assembly.GetName().Version;
+					var x = result.GetType().Assembly;
+					object[] v = x.GetCustomAttributes(typeof(AssemblyFileVersionAttribute), true);
+					Version ver = null;
+					if ((v != null) && (v.Length > 0))
+						ver = new Version(((AssemblyFileVersionAttribute)v[0]).Version);
+					else
+						ver = result.GetType().Assembly.GetName().Version;
+					if (ver.Revision < 0) ver = new Version(ver.Major, ver.Minor, ver.Build, 0);
+					dPlugins[result.GetType().FullName] = ver;
 				}
 			}
 			catch (Exception) { }
@@ -231,7 +239,7 @@ namespace PluginTools
 			Version v = new Version(0, 0);
 			GetLoadedPluginsName().TryGetValue(sPluginName.Replace("Ext", string.Empty) + "." + sPluginName, out v);
 			if (v == null) PluginDebug.AddError("Could not get loaded plugins' data", 0);
-			string ver = v.ToString();
+			string ver = (v == null) ? "???" : v.ToString();
 			if (ver.EndsWith(".0")) ver = ver.Substring(0, ver.Length - 2);
 			else ver += " (Dev)";
 			lvi.SubItems.Add(ver);

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Sie können alle Werte angeben oder Standardwerte für die Build- und Revisionsnummern verwenden,
 // indem Sie "*" wie unten gezeigt eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.0.1")]
-[assembly: AssemblyFileVersion("0.9.0.1")]
+[assembly: AssemblyVersion("0.9.1")]
+[assembly: AssemblyFileVersion("0.9.1")]

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Sie können alle Werte angeben oder Standardwerte für die Build- und Revisionsnummern verwenden,
 // indem Sie "*" wie unten gezeigt eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9")]
-[assembly: AssemblyFileVersion("0.9")]
+[assembly: AssemblyVersion("0.9.0.1")]
+[assembly: AssemblyFileVersion("0.9.0.1")]

--- a/version.info
+++ b/version.info
@@ -1,5 +1,5 @@
 :
-ColoredPassword:0.9
+ColoredPassword:0.9.0.1
 ColoredPassword!de:4
 ColoredPassword!pl:2
 ColoredPassword!ru:2

--- a/version.info
+++ b/version.info
@@ -1,5 +1,5 @@
 :
-ColoredPassword:0.9.0.1
+ColoredPassword:0.9.1
 ColoredPassword!de:4
 ColoredPassword!pl:2
 ColoredPassword!ru:2


### PR DESCRIPTION
Let Windows draw all columns beside password column …
Use OwnerDraw = true on Linux as otherwise menus will not be shown
Entry view: Ensure spaces in passwords are shown as well
Cleanup code

closes #1 